### PR TITLE
🐛 fix: prevent double response send and propagate fetch errors

### DIFF
--- a/src/helpers/asyncGeneratorPaginate.ts
+++ b/src/helpers/asyncGeneratorPaginate.ts
@@ -5,18 +5,10 @@ export async function* asyncGeneratorPaginate(
   page: number = 1
 ) {
   while (true) {
-    try {
-      const data = await func(...args, limit, page);
-      page++;
+    const data = await func(...args, limit, page);
+    page++;
 
-      yield data;
-      if (data.length < limit) break;
-    } catch (error) {
-      console.warn(`exception during fetch`, error);
-      yield {
-        done: true,
-        value: "error",
-      };
-    }
+    yield data;
+    if (data.length < limit) break;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,9 +14,9 @@ app.post(
       response.send("Success");
     } catch (error) {
       if (error instanceof Error) {
-        response.status(400).send(error?.message);
+        return response.status(400).send(error.message);
       }
-      response.status(500).send("Internal Server Error");
+      return response.status(500).send("Internal Server Error");
     }
   }
 );


### PR DESCRIPTION
## Summary
- `server.ts`: added `return` to error branches so the 400 response no longer falls through into a second `response.send`, fixing `ERR_HTTP_HEADERS_SENT` observed in production logs.
- `asyncGeneratorPaginate`: removed the try/catch that swallowed fetch errors and yielded a non-iterable `{ done, value }` sentinel. The controller's `for await (...) following.push(...data)` would then spread that object and throw. Errors now propagate up to the Express handler, which returns the real GitHub error message.

## Context
Production crash on Render:
```
exception during fetch Error: Error fetching following
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```
Two bugs compounded: the generator hid the underlying GitHub API failure (likely token/scope issue), then the handler double-sent.

## Test plan
- [ ] `yarn build` succeeds
- [ ] `yarn dev` boots, `POST /syncFollowers/:login` with valid token returns `Success`
- [ ] With invalid `AUTH_GITHUB`, request returns 400 with GitHub error message (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)