### PR TITLE
🐛 fix: add User-Agent header to GitHub requests + surface error status

### DIFF
--- a/src/config/github.ts
+++ b/src/config/github.ts
@@ -1,0 +1,9 @@
+export function githubHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${process.env.AUTH_GITHUB}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    // GitHub's REST API rejects requests without a User-Agent (403).
+    "User-Agent": "sync-github-followers",
+  };
+}

--- a/src/services/follow.ts
+++ b/src/services/follow.ts
@@ -1,16 +1,21 @@
+import { githubHeaders } from "@/config/github";
+
 export async function followUser({ login }: { login: string }) {
-  const { ok, status } = await fetch(
+  const response = await fetch(
     `https://api.github.com/user/following/${login}`,
     {
-      headers: {
-        Authorization: `Bearer ${process.env.AUTH_GITHUB}`,
-      },
+      headers: githubHeaders(),
       method: "PUT",
     }
   );
 
-  if (!ok) throw new Error("Error when trying to follow");
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Error when trying to follow ${login} (${response.status} ${response.statusText}): ${body}`
+    );
+  }
 
-  console.log("User followed!");
-  return { status };
+  console.log(`User followed: ${login}`);
+  return { status: response.status };
 }

--- a/src/services/followers.ts
+++ b/src/services/followers.ts
@@ -1,3 +1,5 @@
+import { githubHeaders } from "@/config/github";
+
 export async function followersService(
   username: string,
   limit: number = 100,
@@ -6,13 +8,16 @@ export async function followersService(
   const response = await fetch(
     `https://api.github.com/users/${username}/followers?per_page=${limit}&page=${page}`,
     {
-      headers: {
-        Authorization: `Bearer ${process.env.AUTH_GITHUB}`,
-      },
+      headers: githubHeaders(),
     }
   );
 
-  if (!response.ok) throw new Error("Error fetching followers");
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Error fetching followers (${response.status} ${response.statusText}): ${body}`
+    );
+  }
 
   return await response.json();
 }

--- a/src/services/following.ts
+++ b/src/services/following.ts
@@ -1,3 +1,5 @@
+import { githubHeaders } from "@/config/github";
+
 export async function followingService(
   username: string,
   limit: number = 100,
@@ -6,13 +8,16 @@ export async function followingService(
   const response = await fetch(
     `https://api.github.com/users/${username}/following?per_page=${limit}&page=${page}`,
     {
-      headers: {
-        Authorization: `Bearer ${process.env.AUTH_GITHUB}`,
-      },
+      headers: githubHeaders(),
     }
   );
 
-  if (!response.ok) throw new Error("Error fetching following");
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Error fetching following (${response.status} ${response.statusText}): ${body}`
+    );
+  }
 
   return await response.json();
 }

--- a/src/services/unfollow.ts
+++ b/src/services/unfollow.ts
@@ -1,16 +1,21 @@
+import { githubHeaders } from "@/config/github";
+
 export async function unfollowUser({ login }: { login: string }) {
-  const { ok, status } = await fetch(
+  const response = await fetch(
     `https://api.github.com/user/following/${login}`,
     {
-      headers: {
-        Authorization: `Bearer ${process.env.AUTH_GITHUB}`,
-      },
+      headers: githubHeaders(),
       method: "DELETE",
     }
   );
 
-  if (!ok) throw new Error("Error when trying to unfollow");
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Error when trying to unfollow ${login} (${response.status} ${response.statusText}): ${body}`
+    );
+  }
 
-  console.log("User unfollowed!");
-  return { status };
+  console.log(`User unfollowed: ${login}`);
+  return { status: response.status };
 }


### PR DESCRIPTION
## Summary
Root cause of the recurring `Error fetching following` on Render: GitHub's REST API **rejects any request without a `User-Agent` header (403)**. None of the service fetches sent one.

- Add `src/config/github.ts` — single source for request headers (`Authorization`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version`, `User-Agent`).
- All four services (`followers`, `following`, `follow`, `unfollow`) now use it, removing duplicated header blocks.
- Thrown errors now include `status`, `statusText` and response body, so a future failure shows *why* (403 / 401 / 404) instead of a generic message.

## Context
Follows #2 (which stopped the `ERR_HTTP_HEADERS_SENT` crash). That fix made the failure return a clean 400 instead of crashing — this PR addresses the *actual* GitHub call failing.

## Test plan
- [x] `yarn build` compiles clean
- [ ] Deploy, `POST /syncFollowers/:login` with valid token returns `Success`
- [ ] On failure, response/body shows real GitHub status + message